### PR TITLE
added numkeys functionality

### DIFF
--- a/lib/scripto.js
+++ b/lib/scripto.js
@@ -143,19 +143,18 @@ function loadScriptsIntoRedis (redisClient, scripts, callback) {
 
 function evalScript(redisClient, script, keys, args, callback) {
 
-
-    var arguments = [keys.length].concat(keys, args);
     var keysLength= keys.length || 0;
-    arguments.unshift(script, keysLength);
+    var arguments = [keysLength].concat(keys, args);
+    arguments.unshift(script);
 
     redisClient.send_command('eval', arguments, callback);
 }
 
 function evalShaScript(redisClient, sha, keys, args, callback) {
 
-    var arguments = [keys.length].concat(keys, args);
     var keysLength= keys.length || 0;
-    arguments.unshift(sha, keysLength);
+    var arguments = [keysLength].concat(keys, args);
+    arguments.unshift(sha);
 
     redisClient.send_command('evalsha', arguments, callback);
 }

--- a/lib/scripto.js
+++ b/lib/scripto.js
@@ -115,7 +115,7 @@ function loadScriptsFromDir(scriptsDir) {
 }
 
 function loadScriptsIntoRedis (redisClient, scripts, callback) {
-    
+
     var cnt = 0;
     var keys = Object.keys(scripts);
     var shas = {};
@@ -143,8 +143,9 @@ function loadScriptsIntoRedis (redisClient, scripts, callback) {
 
 function evalScript(redisClient, script, keys, args, callback) {
 
+
     var arguments = [keys.length].concat(keys, args);
-    arguments.unshift(script);
+    arguments.unshift(script, keys.length);
 
     redisClient.send_command('eval', arguments, callback);
 }
@@ -152,7 +153,7 @@ function evalScript(redisClient, script, keys, args, callback) {
 function evalShaScript(redisClient, sha, keys, args, callback) {
 
     var arguments = [keys.length].concat(keys, args);
-    arguments.unshift(sha);
+    arguments.unshift(sha, keys.length);
 
     redisClient.send_command('evalsha', arguments, callback);
 }

--- a/lib/scripto.js
+++ b/lib/scripto.js
@@ -145,7 +145,8 @@ function evalScript(redisClient, script, keys, args, callback) {
 
 
     var arguments = [keys.length].concat(keys, args);
-    arguments.unshift(script, keys.length);
+    var keysLength= keys.length || 0;
+    arguments.unshift(script, keysLength);
 
     redisClient.send_command('eval', arguments, callback);
 }
@@ -153,7 +154,8 @@ function evalScript(redisClient, script, keys, args, callback) {
 function evalShaScript(redisClient, sha, keys, args, callback) {
 
     var arguments = [keys.length].concat(keys, args);
-    arguments.unshift(sha, keys.length);
+    var keysLength= keys.length || 0;
+    arguments.unshift(sha, keysLength);
 
     redisClient.send_command('evalsha', arguments, callback);
 }


### PR DESCRIPTION
http://redis.io/commands/eval

Redis eval protocol might have changed a bit since your last commit.
The first argument (after the script itself) should be the number of keys following.  
So this works with current version. (~2.8)
