### PR TITLE
Only loading *.lua files from script directory. Fixes #4

### DIFF
--- a/lib/scripto.js
+++ b/lib/scripto.js
@@ -99,14 +99,19 @@ function Scripto (redisClient) {
 module.exports = Scripto;
 
 function loadScriptsFromDir(scriptsDir) {
+    var EXT = '.lua';
 
     var names = fs.readdirSync(scriptsDir);
     var scripts = {};
 
     names.forEach(function(name) {
+        if (name.substring(name.length - EXT.length, name.length) !== EXT) {
+            // This is not a Lua script
+            return;
+        }
 
         var filename = path.resolve(scriptsDir, name);
-        var key = name.replace('.lua', '');
+        var key = name.replace(EXT, '');
 
         scripts[key] = fs.readFileSync(filename, 'utf8');
     });


### PR DESCRIPTION
Fixes issues where files in the script directory are loaded even if they're not Lua scripts, such as IDE temporary files.
