### PR TITLE
Update dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+  - linux
+  - osx
 language: node_js
 node_js:
   - 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
   - 4
   - 6
   - 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
   - 0.8
+  - 4
+  - 6
+  - 8
 services:
   - redis-server

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/arunoda/node-redis-scripto.git"
   },
   "engines": {
-    "node": ">= 0.8.x"
+    "node": ">= 4"
   },
   "scripts": {
     "test": "test/index.js"

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "test": "test/index.js"
   },
   "dependencies": {
-    "redis": "0.8.x",
-    "debug": "0.7.x"
+    "redis": "^2.8.0",
+    "debug": "^3.1.0"
   },
   "devDependencies": {
-    "mocha": "1.x.x"
+    "mocha": "^3.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "debug": "^3.1.0"
   },
   "devDependencies": {
-    "mocha": "^3.5.3"
+    "mocha": "^4.0.1"
   }
 }


### PR DESCRIPTION
`redis-scripto` was currently using an old version of `debug` that just had a [vulnerability](https://nodesecurity.io/advisories/534) disclosed.  I went ahead and updated the other dependencies as well.